### PR TITLE
Fix messageHandler terminating before connection is opened

### DIFF
--- a/src/buttplugclient.cpp
+++ b/src/buttplugclient.cpp
@@ -33,10 +33,6 @@ void Client::connect(void (*callFunc)(const mhl::Messages)) {
 	webSocket.start();
 	isConnecting = 1;
 
-	// Start a message handler thread and detach it.
-	std::thread messageHandler(&Client::messageHandling, this);
-	messageHandler.detach();
-
 	// Connect to server, specifically send a RequestServerInfo
 	connectServer();
 }
@@ -85,6 +81,11 @@ void Client::callbackFunction(const ix::WebSocketMessagePtr& msg) {
 	// Set atomic variable that websocket is connected once it is open.
 	if (msg->type == ix::WebSocketMessageType::Open) {
 		wsConnected = true;
+
+		// Start a message handler thread and detach it.
+		std::thread messageHandler(&Client::messageHandling, this);
+		messageHandler.detach();
+
 		condWs.notify_all();
 	}
 	


### PR DESCRIPTION
Fixes a race condition that causes the messageHandler thread to give up on a connection before it's able to fully start.